### PR TITLE
fix: price keyboard input breaks when guess is less than min

### DIFF
--- a/src/lib/components/PriceSlider.svelte
+++ b/src/lib/components/PriceSlider.svelte
@@ -3,7 +3,12 @@
 	let { sliderMin = 0, sliderMax = 500_000, guessValue = $bindable(sliderMin), children } = $props();
 
 	const clamp = (val, min, max) => Math.min(Math.max(val, min), max);
-	let restrictedGuess = $derived(clamp(guessValue, sliderMin, sliderMax));
+	let restrictedGuess = $derived.by(() => {
+		if(guessValue < sliderMin) {
+			return guessValue;
+		}
+		return clamp(guessValue, sliderMin, sliderMax);
+	});
 
 	// Initialize the Howl sound instance for the coin click
 	const coinClickSound = new Howl({ src: ["/sounds/price_click.webm"], volume: 0.25 });

--- a/src/lib/utils/gameFunctions.js
+++ b/src/lib/utils/gameFunctions.js
@@ -146,6 +146,8 @@ function addLastQuestionToRoundLog() {
 
 // Get percentage difference between guess & actual price
 export function percentageDifference() {
+    if(get(guessResult) < get(priceRange)?.min) guessResult.set(get(priceRange)?.min) // Ensure guess is within range
+    if(get(guessResult) > get(priceRange).max) guessResult.set(get(priceRange)?.max) // Probably not needed, but just in case
     if (get(question).answer === 0 && get(guessResult) === 0) return 0;
     const base = (Math.abs(get(question).answer) + Math.abs(get(guessResult))) / 2; // Calculate the base as the average of absolute values
     const difference = Math.abs(get(question).answer - get(guessResult)); // Calculate the absolute difference


### PR DESCRIPTION
The issue was caused when the user would enter a number less than the slider minimum. The clamp() function would restrict them and only show the minimum. Now the user can enter a price lower than the minimum. However, if they used that as their guess it'll just default to the minimum again. 

I think that when they do that though, the issue we had of the slider starting at the end shows up again. (like if they guess a number smaller than the minimum, on the next screen the slider thumb will start at the end) I tried to fix it but couldn't.